### PR TITLE
Bring AES controller up to ACK runtime v0.1.0

### DIFF
--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -16,7 +16,16 @@
 package v1alpha1
 
 import (
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	"github.com/aws/aws-sdk-go/aws"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Hack to avoid import errors during build...
+var (
+	_ = &metav1.Time{}
+	_ = &aws.JSONValue{}
+	_ = ackv1alpha1.AWSAccountID("")
 )
 
 type AccessPoliciesStatus struct {

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -28,6 +28,7 @@ import (
 
 	svctypes "github.com/aws-controllers-k8s/elasticsearchservice-controller/apis/v1alpha1"
 	svcresource "github.com/aws-controllers-k8s/elasticsearchservice-controller/pkg/resource"
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 
 	_ "github.com/aws-controllers-k8s/elasticsearchservice-controller/pkg/resource/elasticsearch_domain"
 )
@@ -42,6 +43,7 @@ var (
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = svctypes.AddToScheme(scheme)
+	_ = ackv1alpha1.AddToScheme(scheme)
 }
 
 func main() {

--- a/config/crd/common/bases/services.k8s.aws_adoptedresources.yaml
+++ b/config/crd/common/bases/services.k8s.aws_adoptedresources.yaml
@@ -1,0 +1,227 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: adoptedresources.services.k8s.aws
+spec:
+  group: services.k8s.aws
+  names:
+    kind: AdoptedResource
+    listKind: AdoptedResourceList
+    plural: adoptedresources
+    singular: adoptedresource
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AdoptedResource is the schema for the AdoptedResource API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AdoptedResourceSpec defines the desired state of the AdoptedResource.
+            properties:
+              aws:
+                description: AWSIdentifiers provide all unique ways to reference an
+                  AWS resource.
+                properties:
+                  arn:
+                    description: ARN is the AWS Resource Name for the resource. It
+                      is a globally unique identifier.
+                    type: string
+                  nameOrID:
+                    description: NameOrId is a user-supplied string identifier for
+                      the resource. It may or may not be globally unique, depending
+                      on the type of resource.
+                    type: string
+                type: object
+              kubernetes:
+                description: TargetKubernetesResource provides all the values necessary
+                  to identify a given ACK type and override any metadata values when
+                  creating a resource of that type.
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  metadata:
+                    description: "ObjectMeta is metadata that all persisted resources
+                      must have, which includes all objects users must create. It
+                      is not possible to use `metav1.ObjectMeta` inside spec, as the
+                      controller-gen automatically converts this to an arbitrary string-string
+                      map. https://github.com/kubernetes-sigs/controller-tools/issues/385
+                      \n Active discussion about inclusion of this field in the spec
+                      is happening in this PR: https://github.com/kubernetes-sigs/controller-tools/pull/395
+                      \n Until this is allowed, or if it never is, we will produce
+                      a subset of the object meta that contains only the fields which
+                      the user is allowed to modify in the metadata."
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      generateName:
+                        description: "GenerateName is an optional prefix, used by
+                          the server, to generate a unique name ONLY IF the Name field
+                          has not been provided. If this field is used, the name returned
+                          to the client will be different than the name passed. This
+                          value will also be combined with a unique suffix. The provided
+                          value has the same validation rules as the Name field, and
+                          may be truncated by the length of the suffix required to
+                          make the value unique on the server. \n If this field is
+                          specified and the generated name exists, the server will
+                          NOT return a 409 - instead, it will either return 201 Created
+                          or 500 with Reason ServerTimeout indicating a unique name
+                          could not be found in the time allotted, and the client
+                          should retry (optionally after the time indicated in the
+                          Retry-After header). \n Applied only if Name is not specified.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      name:
+                        description: 'Name must be unique within a namespace. Is required
+                          when creating resources, although some resources may allow
+                          a client to request the generation of an appropriate name
+                          automatically. Name is primarily intended for creation idempotence
+                          and configuration definition. Cannot be updated. More info:
+                          http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                      namespace:
+                        description: "Namespace defines the space within each name
+                          must be unique. An empty namespace is equivalent to the
+                          \"default\" namespace, but \"default\" is the canonical
+                          representation. Not all objects are required to be scoped
+                          to a namespace - the value of this field for those objects
+                          will be empty. \n Must be a DNS_LABEL. Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/namespaces"
+                        type: string
+                      ownerReferences:
+                        description: List of objects depended by this object. If ALL
+                          objects in the list have been deleted, this object will
+                          be garbage collected. If this object is managed by a controller,
+                          then an entry in this list will point to this controller,
+                          with the controller field set to true. There cannot be more
+                          than one managing controller.
+                        items:
+                          description: OwnerReference contains enough information
+                            to let you identify an owning object. An owning object
+                            must be in the same namespace as the dependent, or be
+                            cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: If true, AND if the owner has the "foregroundDeletion"
+                                finalizer, then the owner cannot be deleted from the
+                                key-value store until this reference is removed. Defaults
+                                to false. To set this field, a user needs "delete"
+                                permission of the owner, otherwise 422 (Unprocessable
+                                Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing
+                                controller.
+                              type: boolean
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                        type: array
+                    type: object
+                required:
+                - group
+                - kind
+                type: object
+            required:
+            - aws
+            - kubernetes
+            type: object
+          status:
+            description: AdoptedResourceStatus defines the observed status of the
+              AdoptedResource.
+            properties:
+              conditions:
+                description: A collection of `ackv1alpha1.Condition` objects that
+                  describe the various terminal states of the adopted resource CR
+                  and its target custom resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/common/kustomization.yaml
+++ b/config/crd/common/kustomization.yaml
@@ -1,0 +1,6 @@
+# This file is NOT auto-generated
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - bases/services.k8s.aws_adoptedresources.yaml

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+bases:
+  - common
 resources:
   - bases/elasticsearchservice.services.k8s.aws_elasticsearchdomains.yaml

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -42,3 +42,23 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - services.k8s.aws
+  resources:
+  - adoptedresources
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - services.k8s.aws
+  resources:
+  - adoptedresources/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/elasticsearchservice-controller
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.0.5
+	github.com/aws-controllers-k8s/runtime v0.1.0
 	github.com/aws/aws-sdk-go v1.37.4
 	github.com/go-logr/logr v0.1.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws-controllers-k8s/runtime v0.0.5 h1:WdcnMNdgagF2MMPQRbDJ5OEzMMgHraCJqvvFj4Sx/5g=
 github.com/aws-controllers-k8s/runtime v0.0.5/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
+github.com/aws-controllers-k8s/runtime v0.1.0 h1:XTBQf7hn0792yuCRy58IZpbZoGMrGCpSK2mZXkof5W4=
+github.com/aws-controllers-k8s/runtime v0.1.0/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
 github.com/aws/aws-sdk-go v1.37.4 h1:tWxrpMK/oRSXVnjUzhGeCWLR00fW0WF4V4sycYPPrJ8=
 github.com/aws/aws-sdk-go v1.37.4/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/resource/elasticsearch_domain/descriptor.go
+++ b/pkg/resource/elasticsearch_domain/descriptor.go
@@ -16,6 +16,7 @@
 package elasticsearch_domain
 
 import (
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -141,4 +142,22 @@ func (d *resourceDescriptor) MarkUnmanaged(
 		panic("nil RuntimeMetaObject in AWSResource")
 	}
 	k8sctrlutil.RemoveFinalizer(obj, finalizerString)
+}
+
+// MarkAdopted places descriptors on the custom resource that indicate the
+// resource was not created from within ACK.
+func (d *resourceDescriptor) MarkAdopted(
+	res acktypes.AWSResource,
+) {
+	obj := res.RuntimeMetaObject()
+	if obj == nil {
+		// Should not happen. If it does, there is a bug in the code
+		panic("nil RuntimeMetaObject in AWSResource")
+	}
+	curr := obj.GetAnnotations()
+	if curr == nil {
+		curr = make(map[string]string)
+	}
+	curr[ackv1alpha1.AnnotationAdopted] = "true"
+	obj.SetAnnotations(curr)
 }

--- a/pkg/resource/elasticsearch_domain/manager.go
+++ b/pkg/resource/elasticsearch_domain/manager.go
@@ -35,8 +35,6 @@ import (
 
 // +kubebuilder:rbac:groups=elasticsearchservice.services.k8s.aws,resources=elasticsearchdomains,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=elasticsearchservice.services.k8s.aws,resources=elasticsearchdomains/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -50,9 +48,9 @@ type resourceManager struct {
 	// metrics contains a collection of Prometheus metric objects that the
 	// service controller and its reconcilers track
 	metrics *ackmetrics.Metrics
-	// rr is the AWSResourceReconciler which can be used for various utility
+	// rr is the Reconciler which can be used for various utility
 	// functions such as querying for Secret values given a SecretReference
-	rr acktypes.AWSResourceReconciler
+	rr acktypes.Reconciler
 	// awsAccountID is the AWS account identifier that contains the resources
 	// managed by this resource manager
 	awsAccountID ackv1alpha1.AWSAccountID
@@ -173,7 +171,7 @@ func newResourceManager(
 	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
-	rr acktypes.AWSResourceReconciler,
+	rr acktypes.Reconciler,
 	sess *session.Session,
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,

--- a/pkg/resource/elasticsearch_domain/manager_factory.go
+++ b/pkg/resource/elasticsearch_domain/manager_factory.go
@@ -49,7 +49,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
-	rr acktypes.AWSResourceReconciler,
+	rr acktypes.Reconciler,
 	sess *session.Session,
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
@@ -72,6 +72,11 @@ func (f *resourceManagerFactory) ManagerFor(
 	}
 	f.rmCache[rmId] = rm
 	return rm, nil
+}
+
+// IsAdoptable returns true if the resource is able to be adopted
+func (f *resourceManagerFactory) IsAdoptable() bool {
+	return true
 }
 
 func newResourceManagerFactory() *resourceManagerFactory {

--- a/pkg/resource/elasticsearch_domain/resource.go
+++ b/pkg/resource/elasticsearch_domain/resource.go
@@ -67,3 +67,15 @@ func (r *resource) RuntimeMetaObject() acktypes.RuntimeMetaObject {
 func (r *resource) Conditions() []*ackv1alpha1.Condition {
 	return r.ko.Status.Conditions
 }
+
+// SetObjectMeta sets the ObjectMeta field for the resource
+func (r *resource) SetObjectMeta(meta metav1.ObjectMeta) {
+	r.ko.ObjectMeta = meta
+}
+
+// SetIdentifiers sets the Spec or Status field that is referenced as the unique
+// resource identifier
+func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {
+	r.ko.Status.ACKResourceMetadata.ARN = identifier.ARN
+	return nil
+}

--- a/pkg/resource/elasticsearch_domain/sdk.go
+++ b/pkg/resource/elasticsearch_domain/sdk.go
@@ -80,6 +80,8 @@ func (rm *resourceManager) sdkFind(
 	}
 	if resp.DomainStatus.AccessPolicies != nil {
 		ko.Spec.AccessPolicies = resp.DomainStatus.AccessPolicies
+	} else {
+		ko.Spec.AccessPolicies = nil
 	}
 	if resp.DomainStatus.AdvancedOptions != nil {
 		f2 := map[string]*string{}
@@ -89,6 +91,8 @@ func (rm *resourceManager) sdkFind(
 			f2[f2key] = &f2val
 		}
 		ko.Spec.AdvancedOptions = f2
+	} else {
+		ko.Spec.AdvancedOptions = nil
 	}
 	if resp.DomainStatus.AdvancedSecurityOptions != nil {
 		f3 := &svcapitypes.AdvancedSecurityOptionsInput{}
@@ -125,6 +129,8 @@ func (rm *resourceManager) sdkFind(
 			f3.SAMLOptions = f3f2
 		}
 		ko.Spec.AdvancedSecurityOptions = f3
+	} else {
+		ko.Spec.AdvancedSecurityOptions = nil
 	}
 	if resp.DomainStatus.CognitoOptions != nil {
 		f4 := &svcapitypes.CognitoOptions{}
@@ -141,12 +147,18 @@ func (rm *resourceManager) sdkFind(
 			f4.UserPoolID = resp.DomainStatus.CognitoOptions.UserPoolId
 		}
 		ko.Spec.CognitoOptions = f4
+	} else {
+		ko.Spec.CognitoOptions = nil
 	}
 	if resp.DomainStatus.Created != nil {
 		ko.Status.Created = resp.DomainStatus.Created
+	} else {
+		ko.Status.Created = nil
 	}
 	if resp.DomainStatus.Deleted != nil {
 		ko.Status.Deleted = resp.DomainStatus.Deleted
+	} else {
+		ko.Status.Deleted = nil
 	}
 	if resp.DomainStatus.DomainEndpointOptions != nil {
 		f7 := &svcapitypes.DomainEndpointOptions{}
@@ -166,12 +178,18 @@ func (rm *resourceManager) sdkFind(
 			f7.TLSSecurityPolicy = resp.DomainStatus.DomainEndpointOptions.TLSSecurityPolicy
 		}
 		ko.Spec.DomainEndpointOptions = f7
+	} else {
+		ko.Spec.DomainEndpointOptions = nil
 	}
 	if resp.DomainStatus.DomainId != nil {
 		ko.Status.DomainID = resp.DomainStatus.DomainId
+	} else {
+		ko.Status.DomainID = nil
 	}
 	if resp.DomainStatus.DomainName != nil {
 		ko.Spec.DomainName = resp.DomainStatus.DomainName
+	} else {
+		ko.Spec.DomainName = nil
 	}
 	if resp.DomainStatus.EBSOptions != nil {
 		f10 := &svcapitypes.EBSOptions{}
@@ -188,6 +206,8 @@ func (rm *resourceManager) sdkFind(
 			f10.VolumeType = resp.DomainStatus.EBSOptions.VolumeType
 		}
 		ko.Spec.EBSOptions = f10
+	} else {
+		ko.Spec.EBSOptions = nil
 	}
 	if resp.DomainStatus.ElasticsearchClusterConfig != nil {
 		f11 := &svcapitypes.ElasticsearchClusterConfig{}
@@ -226,9 +246,13 @@ func (rm *resourceManager) sdkFind(
 			f11.ZoneAwarenessEnabled = resp.DomainStatus.ElasticsearchClusterConfig.ZoneAwarenessEnabled
 		}
 		ko.Spec.ElasticsearchClusterConfig = f11
+	} else {
+		ko.Spec.ElasticsearchClusterConfig = nil
 	}
 	if resp.DomainStatus.ElasticsearchVersion != nil {
 		ko.Spec.ElasticsearchVersion = resp.DomainStatus.ElasticsearchVersion
+	} else {
+		ko.Spec.ElasticsearchVersion = nil
 	}
 	if resp.DomainStatus.EncryptionAtRestOptions != nil {
 		f13 := &svcapitypes.EncryptionAtRestOptions{}
@@ -239,9 +263,13 @@ func (rm *resourceManager) sdkFind(
 			f13.KMSKeyID = resp.DomainStatus.EncryptionAtRestOptions.KmsKeyId
 		}
 		ko.Spec.EncryptionAtRestOptions = f13
+	} else {
+		ko.Spec.EncryptionAtRestOptions = nil
 	}
 	if resp.DomainStatus.Endpoint != nil {
 		ko.Status.Endpoint = resp.DomainStatus.Endpoint
+	} else {
+		ko.Status.Endpoint = nil
 	}
 	if resp.DomainStatus.Endpoints != nil {
 		f15 := map[string]*string{}
@@ -251,6 +279,8 @@ func (rm *resourceManager) sdkFind(
 			f15[f15key] = &f15val
 		}
 		ko.Status.Endpoints = f15
+	} else {
+		ko.Status.Endpoints = nil
 	}
 	if resp.DomainStatus.LogPublishingOptions != nil {
 		f16 := map[string]*svcapitypes.LogPublishingOption{}
@@ -265,6 +295,8 @@ func (rm *resourceManager) sdkFind(
 			f16[f16key] = f16val
 		}
 		ko.Spec.LogPublishingOptions = f16
+	} else {
+		ko.Spec.LogPublishingOptions = nil
 	}
 	if resp.DomainStatus.NodeToNodeEncryptionOptions != nil {
 		f17 := &svcapitypes.NodeToNodeEncryptionOptions{}
@@ -272,9 +304,13 @@ func (rm *resourceManager) sdkFind(
 			f17.Enabled = resp.DomainStatus.NodeToNodeEncryptionOptions.Enabled
 		}
 		ko.Spec.NodeToNodeEncryptionOptions = f17
+	} else {
+		ko.Spec.NodeToNodeEncryptionOptions = nil
 	}
 	if resp.DomainStatus.Processing != nil {
 		ko.Status.Processing = resp.DomainStatus.Processing
+	} else {
+		ko.Status.Processing = nil
 	}
 	if resp.DomainStatus.ServiceSoftwareOptions != nil {
 		f19 := &svcapitypes.ServiceSoftwareOptions{}
@@ -303,6 +339,8 @@ func (rm *resourceManager) sdkFind(
 			f19.UpdateStatus = resp.DomainStatus.ServiceSoftwareOptions.UpdateStatus
 		}
 		ko.Status.ServiceSoftwareOptions = f19
+	} else {
+		ko.Status.ServiceSoftwareOptions = nil
 	}
 	if resp.DomainStatus.SnapshotOptions != nil {
 		f20 := &svcapitypes.SnapshotOptions{}
@@ -310,9 +348,13 @@ func (rm *resourceManager) sdkFind(
 			f20.AutomatedSnapshotStartHour = resp.DomainStatus.SnapshotOptions.AutomatedSnapshotStartHour
 		}
 		ko.Spec.SnapshotOptions = f20
+	} else {
+		ko.Spec.SnapshotOptions = nil
 	}
 	if resp.DomainStatus.UpgradeProcessing != nil {
 		ko.Status.UpgradeProcessing = resp.DomainStatus.UpgradeProcessing
+	} else {
+		ko.Status.UpgradeProcessing = nil
 	}
 	if resp.DomainStatus.VPCOptions != nil {
 		f22 := &svcapitypes.VPCOptions{}
@@ -335,6 +377,8 @@ func (rm *resourceManager) sdkFind(
 			f22.SubnetIDs = f22f2
 		}
 		ko.Spec.VPCOptions = f22
+	} else {
+		ko.Spec.VPCOptions = nil
 	}
 
 	rm.setStatusDefaults(ko)
@@ -395,15 +439,23 @@ func (rm *resourceManager) sdkCreate(
 	}
 	if resp.DomainStatus.Created != nil {
 		ko.Status.Created = resp.DomainStatus.Created
+	} else {
+		ko.Status.Created = nil
 	}
 	if resp.DomainStatus.Deleted != nil {
 		ko.Status.Deleted = resp.DomainStatus.Deleted
+	} else {
+		ko.Status.Deleted = nil
 	}
 	if resp.DomainStatus.DomainId != nil {
 		ko.Status.DomainID = resp.DomainStatus.DomainId
+	} else {
+		ko.Status.DomainID = nil
 	}
 	if resp.DomainStatus.Endpoint != nil {
 		ko.Status.Endpoint = resp.DomainStatus.Endpoint
+	} else {
+		ko.Status.Endpoint = nil
 	}
 	if resp.DomainStatus.Endpoints != nil {
 		f15 := map[string]*string{}
@@ -413,9 +465,13 @@ func (rm *resourceManager) sdkCreate(
 			f15[f15key] = &f15val
 		}
 		ko.Status.Endpoints = f15
+	} else {
+		ko.Status.Endpoints = nil
 	}
 	if resp.DomainStatus.Processing != nil {
 		ko.Status.Processing = resp.DomainStatus.Processing
+	} else {
+		ko.Status.Processing = nil
 	}
 	if resp.DomainStatus.ServiceSoftwareOptions != nil {
 		f19 := &svcapitypes.ServiceSoftwareOptions{}
@@ -444,9 +500,13 @@ func (rm *resourceManager) sdkCreate(
 			f19.UpdateStatus = resp.DomainStatus.ServiceSoftwareOptions.UpdateStatus
 		}
 		ko.Status.ServiceSoftwareOptions = f19
+	} else {
+		ko.Status.ServiceSoftwareOptions = nil
 	}
 	if resp.DomainStatus.UpgradeProcessing != nil {
 		ko.Status.UpgradeProcessing = resp.DomainStatus.UpgradeProcessing
+	} else {
+		ko.Status.UpgradeProcessing = nil
 	}
 
 	rm.setStatusDefaults(ko)
@@ -755,10 +815,13 @@ func (rm *resourceManager) updateConditions(
 
 	// Terminal condition
 	var terminalCondition *ackv1alpha1.Condition = nil
+	var recoverableCondition *ackv1alpha1.Condition = nil
 	for _, condition := range ko.Status.Conditions {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
 			terminalCondition = condition
-			break
+		}
+		if condition.Type == ackv1alpha1.ConditionTypeRecoverable {
+			recoverableCondition = condition
 		}
 	}
 
@@ -773,11 +836,34 @@ func (rm *resourceManager) updateConditions(
 		awsErr, _ := ackerr.AWSError(err)
 		errorMessage := awsErr.Message()
 		terminalCondition.Message = &errorMessage
-	} else if terminalCondition != nil {
-		terminalCondition.Status = corev1.ConditionFalse
-		terminalCondition.Message = nil
+	} else {
+		// Clear the terminal condition if no longer present
+		if terminalCondition != nil {
+			terminalCondition.Status = corev1.ConditionFalse
+			terminalCondition.Message = nil
+		}
+		// Handling Recoverable Conditions
+		if err != nil {
+			if recoverableCondition == nil {
+				// Add a new Condition containing a non-terminal error
+				recoverableCondition = &ackv1alpha1.Condition{
+					Type: ackv1alpha1.ConditionTypeRecoverable,
+				}
+				ko.Status.Conditions = append(ko.Status.Conditions, recoverableCondition)
+			}
+			recoverableCondition.Status = corev1.ConditionTrue
+			awsErr, _ := ackerr.AWSError(err)
+			errorMessage := err.Error()
+			if awsErr != nil {
+				errorMessage = awsErr.Message()
+			}
+			recoverableCondition.Message = &errorMessage
+		} else if recoverableCondition != nil {
+			recoverableCondition.Status = corev1.ConditionFalse
+			recoverableCondition.Message = nil
+		}
 	}
-	if terminalCondition != nil {
+	if terminalCondition != nil || recoverableCondition != nil {
 		return &resource{ko}, true // updated
 	}
 	return nil, false // not updated

--- a/pkg/resource/registry.go
+++ b/pkg/resource/registry.go
@@ -20,6 +20,11 @@ import (
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
+// +kubebuilder:rbac:groups=services.k8s.aws,resources=adoptedresources,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=services.k8s.aws,resources=adoptedresources/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+
 var (
 	reg = ackrt.NewRegistry()
 )


### PR DESCRIPTION
Updated the go.mod to reference ACK runtime v0.1.0 and regenerated the
controller.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
