### PR TITLE
add initial AES Domain e2e test

### DIFF
--- a/test/e2e/__init__.py
+++ b/test/e2e/__init__.py
@@ -1,0 +1,64 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import pytest
+from typing import Dict, Any
+from pathlib import Path
+
+from acktest.k8s import resource
+from acktest.resources import load_resource_file
+
+SERVICE_NAME = "elasticsearchservice"
+CRD_GROUP = "elasticsearchservice.services.k8s.aws"
+CRD_VERSION = "v1alpha1"
+
+# PyTest marker for the current service
+service_marker = pytest.mark.service(arg=SERVICE_NAME)
+bootstrap_directory = Path(__file__).parent
+resource_directory = Path(__file__).parent / "resources"
+
+def load_resource(
+        resource_name: str,
+        additional_replacements: Dict[str, Any] = {},
+):
+    """Calls acktest.resources.load_resource_file to access the specific
+    resources directory for the current service.
+    """
+    return load_resource_file(
+        resource_directory,
+        resource_name,
+        additional_replacements=additional_replacements,
+    )
+
+def create_resource(
+    resource_plural,
+    resource_name,
+    spec_file,
+    replacements,
+    namespace="default",
+):
+    """Wrapper around acktest.k8s.load_and_create_resource to create a CR
+    through the k8s API.
+    """
+    reference, spec, resource = resource.load_and_create_resource(
+        resource_directory,
+        CRD_GROUP,
+        CRD_VERSION,
+        resource_plural,
+        resource_name,
+        spec_file,
+        replacements,
+        namespace,
+    )
+
+    return reference, spec, resource

--- a/test/e2e/bootstrap_resources.py
+++ b/test/e2e/bootstrap_resources.py
@@ -1,0 +1,37 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""Declares the structure of the bootstrapped resources and provides a loader
+for them.
+"""
+from dataclasses import dataclass
+
+from e2e import bootstrap_directory
+from acktest.resources import read_bootstrap_config
+
+VPC_CIDR_BLOCK = "10.0.82.0/28"
+VPC_SUBNET_CIDR_BLOCK = "10.0.82.0/28"
+
+@dataclass
+class TestBootstrapResources:
+    VPCID: str
+    VPCSubnetID: str
+
+_bootstrap_resources = None
+
+def get_bootstrap_resources(bootstrap_file_name: str = "bootstrap.yaml"):
+    global _bootstrap_resources
+    if _bootstrap_resources is None:
+        _bootstrap_resources = TestBootstrapResources(
+            **read_bootstrap_config(bootstrap_directory, bootstrap_file_name=bootstrap_file_name),
+        )
+    return _bootstrap_resources

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -1,0 +1,48 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import os
+import pytest
+
+from acktest import k8s
+
+
+def pytest_addoption(parser):
+    parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "canary: mark test to also run in canary tests"
+    )
+    config.addinivalue_line(
+        "markers", "service(arg): mark test associated with a given service"
+    )
+    config.addinivalue_line(
+        "markers", "slow: mark test as slow to run"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
+
+
+# Provide a k8s client to interact with the integration test cluster
+@pytest.fixture(scope='class')
+def k8s_client():
+    return k8s._get_k8s_api_client()

--- a/test/e2e/replacement_values.py
+++ b/test/e2e/replacement_values.py
@@ -1,0 +1,19 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Stores the values used by each of the integration tests for replacing the
+AES-specific test variables.
+"""
+
+REPLACEMENT_VALUES = {
+}

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,0 +1,1 @@
+acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@955d7831ee374a212250179e95a5f3b75e555fd9

--- a/test/e2e/resources/domain_es7.9.yaml
+++ b/test/e2e/resources/domain_es7.9.yaml
@@ -1,0 +1,7 @@
+apiVersion: elasticsearchservice.services.k8s.aws/v1alpha1
+kind: ElasticsearchDomain
+metadata:
+  name: $DOMAIN_NAME
+spec:
+  domainName: $DOMAIN_NAME
+  elasticsearchVersion: "7.9"

--- a/test/e2e/service_bootstrap.py
+++ b/test/e2e/service_bootstrap.py
@@ -1,0 +1,109 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""Bootstraps the resources required to run the Elasticsearch Service
+integration tests.
+"""
+
+import boto3
+import logging
+import time
+
+from acktest.aws import identity
+from acktest import resources
+
+from e2e import bootstrap_directory
+from e2e.bootstrap_resources import (
+    TestBootstrapResources,
+    VPC_CIDR_BLOCK,
+    VPC_SUBNET_CIDR_BLOCK,
+)
+
+
+def create_vpc() -> str:
+    region = identity.get_region()
+    ec2 = boto3.client("ec2", region_name=region)
+
+    logging.debug(f"Creating VPC with CIDR {VPC_CIDR_BLOCK}")
+
+    resp = ec2.create_vpc(
+        CidrBlock=VPC_CIDR_BLOCK,
+    )
+    vpc_id = resp['Vpc']['VpcId']
+
+    # TODO(jaypipes): Put a proper waiter here...
+    time.sleep(3)
+
+    vpcs = ec2.describe_vpcs(VpcIds=[vpc_id])
+    if len(vpcs['Vpcs']) != 1:
+        raise RuntimeError(
+            f"failed to describe VPC we just created '{vpc_id}'",
+        )
+
+    vpc = vpcs['Vpcs'][0]
+    vpc_state = vpc['State']
+    if vpc_state != "available":
+        raise RuntimeError(
+            f"VPC we just created '{vpc_id}' is not available. current state: {vpc_state}",
+        )
+
+    logging.info(f"Created VPC {vpc_id}")
+
+    return vpc_id
+
+
+def create_subnet(vpc_id: str) -> str:
+    region = identity.get_region()
+    ec2 = boto3.client("ec2", region_name=region)
+
+    resp = ec2.create_subnet(
+        CidrBlock=VPC_SUBNET_CIDR_BLOCK,
+        VpcId=vpc_id,
+    )
+    subnet_id = resp['Subnet']['SubnetId']
+
+    # TODO(jaypipes): Put a proper waiter here...
+    time.sleep(3)
+
+    subnets  = ec2.describe_subnets(SubnetIds=[subnet_id])
+    if len(subnets['Subnets']) != 1:
+        raise RuntimeError(
+            f"failed to describe subnet we just created '{subnet_id}'",
+        )
+
+    subnet = subnets['Subnets'][0]
+    subnet_state = subnet['State']
+    if subnet_state != "available":
+        raise RuntimeError(
+            f"Subnet we just created '{subnet_id}' is not available. current state: {subnet_state}",
+        )
+
+    logging.info(f"Created VPC Subnet {subnet_id}")
+
+    return subnet_id
+
+
+def service_bootstrap() -> dict:
+    logging.getLogger().setLevel(logging.INFO)
+
+    vpc_id = create_vpc()
+    subnet_id = create_subnet(vpc_id)
+
+    return TestBootstrapResources(
+        vpc_id,
+        subnet_id,
+    ).__dict__
+
+
+if __name__ == "__main__":
+    config = service_bootstrap()
+    resources.write_bootstrap_config(config, bootstrap_directory)

--- a/test/e2e/service_cleanup.py
+++ b/test/e2e/service_cleanup.py
@@ -1,0 +1,65 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Cleans up the resources created by the bootstrapping process.
+"""
+
+import boto3
+import logging
+
+from acktest import resources
+from acktest.aws import identity
+
+from e2e import bootstrap_directory
+from e2e.bootstrap_resources import TestBootstrapResources
+
+
+def delete_subnet(subnet_id: str):
+    region = identity.get_region()
+    ec2 = boto3.client("ec2", region_name=region)
+
+    ec2.delete_subnet(SubnetId=subnet_id)
+
+    logging.info(f"Deleted VPC Subnet {subnet_id}")
+
+
+def delete_vpc(vpc_id: str):
+    region = identity.get_region()
+    ec2 = boto3.client("ec2", region_name=region)
+
+    ec2.delete_vpc(VpcId=vpc_id)
+
+    logging.info(f"Deleted VPC {vpc_id}")
+
+
+def service_cleanup(config: dict):
+    logging.getLogger().setLevel(logging.INFO)
+
+    resources = TestBootstrapResources(
+        **config
+    )
+
+    try:
+        delete_subnet(resources.VPCSubnetID)
+    except:
+        logging.exception(f"Unable to delete VPC subnet {resources.VPCSubnetID}")
+
+    try:
+        delete_vpc(resources.VPCID)
+    except:
+        logging.exception(f"Unable to delete VPC {resources.VPCID}")
+
+
+if __name__ == "__main__":   
+    bootstrap_config = resources.read_bootstrap_config(bootstrap_directory)
+    service_cleanup(bootstrap_config) 

--- a/test/e2e/tests/test_elasticsearch_domain.py
+++ b/test/e2e/tests/test_elasticsearch_domain.py
@@ -1,0 +1,108 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Integration tests for the ElasticsearchService API ElasticsearchDomain
+resource
+"""
+
+import boto3
+import datetime
+import pytest
+import logging
+import time
+from typing import Dict
+
+from acktest.k8s import resource as k8s
+
+from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_resource
+from e2e.replacement_values import REPLACEMENT_VALUES
+
+RESOURCE_PLURAL = 'elasticsearchdomains'
+
+DELETE_WAIT_AFTER_SECONDS = 20
+CREATE_INTERVAL_SLEEP_SECONDS = 15
+# Time to wait before we get to an expected RUNNING state.
+# In my experience, it regularly takes more than 6 minutes to create a
+# single-instance RabbitMQ broker...
+CREATE_TIMEOUT_SECONDS = 600
+
+
+@pytest.fixture(scope="module")
+def es_client():
+    return boto3.client('es')
+
+
+# TODO(jaypipes): Move to k8s common library
+def get_resource_arn(self, resource: Dict):
+    assert 'ackResourceMetadata' in resource['status'] and \
+        'arn' in resource['status']['ackResourceMetadata']
+    return resource['status']['ackResourceMetadata']['arn']
+
+
+@service_marker
+@pytest.mark.canary
+class TestDomain:
+    def test_create_delete_7_9(self, es_client):
+        resource_name = "my-es-domain"
+
+        replacements = REPLACEMENT_VALUES.copy()
+        replacements["DOMAIN_NAME"] = resource_name
+
+        resource_data = load_resource(
+            "domain_es7.9",
+            additional_replacements=replacements,
+        )
+        logging.error(resource_data)
+
+        # Create the k8s resource
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            resource_name, namespace="default",
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+
+        assert cr is not None
+        assert k8s.get_resource_exists(ref)
+
+        logging.info(cr)
+
+        # Let's check that the domain appears in AES
+        aws_res = es_client.describe_elasticsearch_domain(DomainName=resource_name)
+        assert aws_res is not None
+
+        now = datetime.datetime.now()
+        timeout = now + datetime.timedelta(seconds=CREATE_TIMEOUT_SECONDS)
+
+        # TODO(jaypipes): Move this into generic AWS-side waiter
+        while aws_res['Created'] != True:
+            if datetime.datetime.now() >= timeout:
+                raise Exception("failed to find created ES Domain before timeout")
+            time.sleep(CREATE_INTERVAL_SLEEP_SECONDS)
+            aws_res = es_client.describe_elasticsearch_domain(DomainName=resource_name)
+            assert aws_res is not None
+
+        # Delete the k8s resource on teardown of the module
+        k8s.delete_custom_resource(ref)
+
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+        # Domain should no longer appear in AES
+        res_found = False
+        try:
+            es_client.describe_elasticsearch_domain(DomainName=resource_name)
+            res_found = True
+        except es_client.exceptions.NotFoundException:
+            pass
+
+        assert res_found is False


### PR DESCRIPTION
Adds the essentials for an e2e test of the AES Domain resource.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
