### PR TITLE
update e2e tests for EBS options

### DIFF
--- a/generator.yaml
+++ b/generator.yaml
@@ -6,3 +6,11 @@ ignore:
   field_paths:
     # SnapshotOptions is irrelevant for Elasticsearch 5.3+
     - CreateElasticsearchDomainRequest.SnapshotOptions
+resources:
+  ElasticsearchDomain:
+    exceptions:
+      errors:
+        404:
+          code: ResourceNotFoundException
+      terminal_codes:
+        - ValidationException

--- a/test/e2e/resources/domain_es7.9.yaml
+++ b/test/e2e/resources/domain_es7.9.yaml
@@ -5,3 +5,9 @@ metadata:
 spec:
   domainName: $DOMAIN_NAME
   elasticsearchVersion: "7.9"
+  # EBSOptions is required for default AES domain instance type
+  # m4.large.elasticsearch
+  ebsOptions:
+    ebsEnabled: true
+    volumeSize: 10
+    volumeType: gp2


### PR DESCRIPTION
We noticed a ValidationException occurred in our test case because
EBSOptions wasn't specified and is required for the default AES
instance type. In addition to telling the code generator about this
TerminalCondition, we had to specify the 404 for ElastisearchDomain was
ResourceNotFoundException because the coral model has the code as 409.

Finally, after running a few iterations of the test, we set timeouts and
waits appropriately for checking the creation/deletion events for an AES
domain.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
