### PR TITLE
Added new test case to create multiaz domain and reformatted code.

### DIFF
--- a/test/e2e/resources/domain_es_xdym_multi_az7.9.yaml
+++ b/test/e2e/resources/domain_es_xdym_multi_az7.9.yaml
@@ -1,0 +1,18 @@
+apiVersion: elasticsearchservice.services.k8s.aws/v1alpha1
+kind: ElasticsearchDomain
+metadata:
+  name: $DOMAIN_NAME
+spec:
+  domainName: $DOMAIN_NAME
+  elasticsearchVersion: "7.9"
+  elasticsearchClusterConfig:
+    dedicatedMasterEnabled: true
+    dedicatedMasterCount: $MASTER_NODE_COUNT
+    instanceCount: $DATA_NODE_COUNT
+    zoneAwarenessEnabled: true
+  # EBSOptions is required for default AES domain instance type
+  # m4.large.elasticsearch
+  ebsOptions:
+    ebsEnabled: true
+    volumeSize: 10
+    volumeType: gp2


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Added a new test to create multi az, multi node domain with dedicated master nodes.
* Added more assertions.
* Reformatted code.

revision 2:
* Using `dataclass` as DTO.
* More readable initialization.
* Proper logging method used. 

#### test output
```
tests/test_elasticsearch_domain.py::TestDomain::test_create_delete_7_9
[gw0] [ 50%] PASSED tests/test_elasticsearch_domain.py::TestDomain::test_create_delete_7_9
tests/test_elasticsearch_domain.py::TestDomain::test_create_delete_2d3m_multi_az_no_vpc_7_9
[gw0] [100%] PASSED tests/test_elasticsearch_domain.py::TestDomain::test_create_delete_2d3m_multi_az_no_vpc_7_9
```

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
